### PR TITLE
- removed references to appsync which came from old repository

### DIFF
--- a/lambda-functions/playersummary-cw-function/index.js
+++ b/lambda-functions/playersummary-cw-function/index.js
@@ -8,12 +8,10 @@
 
 require('es6-promise').polyfill();
 require('isomorphic-fetch');
-const URL = require('url');
 const AWS = require('aws-sdk');
 // Create CloudWatch service object
 var cw = new AWS.CloudWatch({ apiVersion: '2010-08-01' });
 
-const GRAPHQL_ENDPOINT = process.env.GRAPHQL_ENDPOINT;
 const DASHBOARD_NAME = process.env.DASHBOARD_NAME;
 
 console.log('Loading function');
@@ -29,8 +27,6 @@ exports.handler = (event, context, callback) => {
         const jsonData = JSON.parse(recordData);
         console.log("data :%j", jsonData);
 
-        const uri = URL.parse(GRAPHQL_ENDPOINT);
-        console.log(uri.href);
         console.log("Region ", process.env.AWS_REGION);
 
         // Create parameters JSON for putMetricData


### PR DESCRIPTION
*Issue 1, if available:*

*Description of changes:*

Removes references to old Appsync code in this lambda function, which was causing it to fail to push to CWMetrics


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
