### PR TITLE
remove build artifacts from git and ensure Makefile isn't tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+Makefile
+
+# build artifacts
+node_modules/
+dist/*.zip
+cloudformation/deployment.yaml
+
+# Python dependencies
+package/
+
+package-lock.json
+yarn.lock


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change adds a .gitignore file to block build artifacts and the Makefile from being tracked in the repo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
