### PR TITLE
Change the Metrics input API from PUT to POST

### DIFF
--- a/cloudformation/deployment_template.yaml
+++ b/cloudformation/deployment_template.yaml
@@ -737,19 +737,19 @@ SELECT STREAM 'LIVE_LATENCY', 'Seconds', \"client_platform\", AVG(\"live_latency
   EventIngestApiDeployment:
     Type: AWS::ApiGateway::Deployment
     DependsOn:
-      - EventIngestApiPUT
+      - EventIngestApiPOST
       - EventIngestApiOPTIONS
     Properties:
       RestApiId: !Ref EventIngestApi
       StageName: prod2
 
-  EventIngestApiPUT:
+  EventIngestApiPOST:
     DependsOn:
       - PlayerLogsDeliveryStream
     Type: AWS::ApiGateway::Method
     Properties:
       AuthorizationType: NONE
-      HttpMethod: PUT
+      HttpMethod: POST
       Integration:
         Type: AWS
         Credentials: !GetAtt EventIngestEndpointRole.Arn

--- a/web/IVSplayer/js/ivs.js
+++ b/web/IVSplayer/js/ivs.js
@@ -276,7 +276,7 @@ const cardInnerEl = $(".card-inner");
 
       $.ajax({
         url: endpoint,
-        type: 'PUT',
+        type: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },


### PR DESCRIPTION
*Issue #, if available:* 13

*Description of changes:* Modifies the API GW API to use a POST method type, rather than PUT for metric delivery. Also updated the ivs.js client side code to POST rather than PUT to this API. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
