### PR TITLE
fix copytemplateww commands

### DIFF
--- a/Makefile.sample
+++ b/Makefile.sample
@@ -57,7 +57,8 @@ copytemplateww:
 	@for region in $(regions);do \
 		echo $$region;	echo $(bucket); \
 		sed -e "s/BUCKET_NAME/${bucket}/g" -e "s/VERSION/${version}/g" cloudformation/deployment_template.yaml > cloudformation/deployment_package.yaml; \
-aws cloudformation package --template-file cloudformation/deployment_package.yaml --s3-bucket $(bucket)-$$region --s3-prefix deploy/lambda-functions --output-template-file cloudformation/deployment.yaml --profile $(profile); \		aws s3 cp cloudformation/deployment.yaml s3://$(bucket)-$$region/qos/cloudformation/$(version)/ --acl public-read --profile $(profile); \
+		aws cloudformation package --template-file cloudformation/deployment_package.yaml --s3-bucket $(bucket)-$$region --s3-prefix deploy/lambda-functions --output-template-file cloudformation/deployment.yaml --profile $(profile); \
+		aws s3 cp cloudformation/deployment.yaml s3://$(bucket)-$$region/qos/cloudformation/$(version)/ --acl public-read --profile $(profile); \
 		done
 
 template:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Small fix for a copy&paste miss in the Makefile. Accidentally removed the command to copy the CloudFormation template to the S3 bucket. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
